### PR TITLE
Apply dark mode to scrollbar on Chromium browsers

### DIFF
--- a/app/css/style.css
+++ b/app/css/style.css
@@ -26,6 +26,33 @@
         -moz-osx-font-smoothing: grayscale;
         text-rendering: geometricPrecision !important;
     }
+
+    @supports (scrollbar-color: dark) {
+        body {
+            scrollbar-color: dark;
+        }
+    }
+
+    @supports not (scrollbar-color: dark) {
+        body::-webkit-scrollbar {
+            background-color: #2e2d2d;
+        }
+
+        body::-webkit-scrollbar-track {
+            box-shadow: inset 0 0 2px #404040;
+        }
+
+        body::-webkit-scrollbar-thumb {
+            background-color: #6d6c6c;
+            border: 4px solid transparent;
+            border-radius: 12px;
+            background-clip: content-box;
+        }
+
+        body::-webkit-scrollbar-thumb:active, body::-webkit-scrollbar-thumb:hover {
+            background-color: #979696;
+        }
+    }
 }
 
 ::-moz-selection {


### PR DESCRIPTION
在桌面平台，Chrome、Edge等浏览器尚不会在深色模式自动将滚动条设为深色。CSS中尽力模仿了Safari在深色模式下的滚动条设计。