### PR TITLE
Move detect-browser to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "tategaki",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tategaki",
-      "version": "1.0.0",
+      "version": "1.0.3",
       "license": "MIT",
-      "dependencies": {
-        "detect-browser": "^5.2.1"
-      },
       "devDependencies": {
+        "detect-browser": "^5.2.1",
         "ts-loader": "^9.2.6",
         "tsc-watch": "^4.5.0",
         "typescript": "^4.4.3",
@@ -924,7 +922,8 @@
     "node_modules/detect-browser": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
-      "integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg=="
+      "integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg==",
+      "dev": true
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
@@ -4637,7 +4636,8 @@
     "detect-browser": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.1.tgz",
-      "integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg=="
+      "integrity": "sha512-eAcRiEPTs7utXWPaAgu/OX1HRJpxW7xSHpw4LTDrGFaeWnJ37HRlqpUkKsDm0AoTbtrvHQhH+5U2Cd87EGhJTg==",
+      "dev": true
     },
     "detect-node": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "type": "git",
     "url": "git+https://github.com/denkiame/tategaki.js.git"
   },
-  "keywords": [ "typography", "cjk" ],
+  "keywords": [
+    "typography",
+    "cjk"
+  ],
   "author": "Toto Minai <the@unpopular.me> (https://chunghwa.asia)",
   "license": "MIT",
   "bugs": {
@@ -19,14 +22,12 @@
   },
   "homepage": "https://github.com/denkiame/tategaki.js#readme",
   "devDependencies": {
+    "detect-browser": "^5.2.1",
     "ts-loader": "^9.2.6",
     "tsc-watch": "^4.5.0",
     "typescript": "^4.4.3",
     "webpack": "^5.53.0",
     "webpack-cli": "^4.8.0",
     "webpack-dev-server": "^4.2.1"
-  },
-  "dependencies": {
-    "detect-browser": "^5.2.1"
   }
 }


### PR DESCRIPTION
The package detect-browser is only used in development environment.